### PR TITLE
fix nil pointer dereference

### DIFF
--- a/internal.go
+++ b/internal.go
@@ -32,7 +32,9 @@ func parse(fset *token.FileSet, filename string, src []byte, fragmentOk bool) (
 	// package line and source fragments are ok, fall through to
 	// try as a source fragment. Stop and return on any other error.
 	if err == nil || !fragmentOk || !strings.Contains(err.Error(), "expected 'package'") {
-		err = checkBadAST(file, err)
+		if err != nil {
+			err = checkBadAST(file, err)
+		}
 		return
 	}
 


### PR DESCRIPTION
checkBadAST() assumes given err is not nil

```go
if !strings.Contains(originalError.Error(), "missing ',' before newline") {
...
```

`originalError` may be nil in current implementation. this pull-request fix it.